### PR TITLE
changed repo name & added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ You can submit your own Quickstarts to be published on Sigma's website by submit
 ### Run locally
 
   1. Fork this repository to your personal github account (top right of webpage, `fork` button)
-  2. Clone your new fork `git clone git@github.com:<YOUR-USERNAME>/sfquickstarts.git sfquickstarts`
-  3. Navigate to the site directory `cd sfquickstarts/site`
+  2. Clone your new fork `git clone git@github.com:<YOUR-USERNAME>/sigmaquickstarts.git sfquickstarts`
+  3. Navigate to the site directory `cd sigmaquickstarts/site`
   4. Install node dependencies `npm install`
   5. Run the site `npm run serve`
 


### PR DESCRIPTION
I changed the repo name in Readme so as not to conflict wtih the sf repository which is called sfquickstarts.

I also added .DS_Store to gitignore for mac os vs code users.