### PR TITLE
Fix benefits list in tables tutorial

### DIFF
--- a/site/sigmaguides/src/Fundamentals 2: Working with Tables/Fundamentals 2: Working with Tables.md
+++ b/site/sigmaguides/src/Fundamentals 2: Working with Tables/Fundamentals 2: Working with Tables.md
@@ -134,9 +134,9 @@ Clicking into the first `Query` gives every last detail:
 <aside class="positive">
 <strong>IMPORTANT:</strong><br> Sigma is unique versus many other BI products in that Sigma is fully-managed SaaS, offers a direct connection to the Cloud Data Warehouse (CDW), and pushes all queries to the CDW for execution. Benefits of this include:
 
-Data accessed by Sigma is always live and accurate
-Unlimited query speed and scale as Sigma leverages the compute resources of the CDW. Queries across millions of rows are performant.
-Stronger security and governance as data never leaves the CDW and it is easy to control permissions via a single point of access. 
+- Data accessed by Sigma is always live and accurate.
+- Unlimited query speed and scale as Sigma leverages the compute resources of the CDW. Queries across millions of rows are performant.
+- Stronger security and governance as data never leaves the CDW and it is easy to control permissions via a single point of access. 
 
 With many other BI products, data is extracted out of the CDW to local desktops/servers for analysis which leads to stale data, limited scale and speed, and security issues with extracts scattered across many desktops and file shares.
 </aside>


### PR DESCRIPTION
This content looks like it's meant to be rendered as a list, but it's rendered as a single paragraph on the site. This PR changes it to render as a list, and gives consistent punctuation to each bullet point.

![Screenshot 2023-05-25 at 1 02 00 PM](https://github.com/sigmacomputing/sigmaquickstarts/assets/326113/868bbb4b-e6d4-45ce-bcf2-f4d3bf3c4a9e)
