### PR TITLE
small tweaks to June Highlights

### DIFF
--- a/site/sigmaguides/src/06_2023_first_friday_features/06_2023_first_friday_features.md
+++ b/site/sigmaguides/src/06_2023_first_friday_features/06_2023_first_friday_features.md
@@ -17,14 +17,14 @@ Release notes for the month of June 2023 features, published on first Friday of 
 6.30.2023
 -->
 
-# 07-2023 (for June)
+# June Highlights
 
 ## Overview 
 Duration: 5 
 
 This QuickStart lists all the new and public beta features released, as well as bugs fixed in June 2023. 
 
-It is summary in nature and you should refer to the specific Sigma documentation links provided for more information.
+It is summary in nature and you should refer to the specific [Sigma documentation](https://help.sigmacomputing.com/hc/en-us) links provided for more information.
 
 **Public beta features will carry the section text "BETA".** 
 
@@ -32,7 +32,7 @@ All other features are considered released (GA or generally available).
  
 Sigma actually has feature and bug fix releases weekly, and high-priority bug fixes on demand. We felt is was best to keep these QuickStarts to a summary of the previous month for your convenance.
 
-New QuickStarts will be published on the first Friday of each month; for the previous month information. 
+New QuickStarts will be published on the first Friday of each month, and will include information for the previous month. 
 
 ![Footer](assets/sigma_footer.png)
 <!-- END OF SECTION-->


### PR DESCRIPTION
- changes `07-2023 (for June)` to June Highlights to make the tab name a bit cleaner
- adds a link to sigma docs in the summary
- changes a bit of language in the last paragraph for the summary

### markdown preview
<img width="629" alt="image" src="https://github.com/sigmacomputing/sigmaquickstarts/assets/20668680/ed55fc47-b6f7-44a9-b738-32de689337f6">
