### PR TITLE
add account_type param example in sfdc embedding

### DIFF
--- a/site/sigmaguides/src/embedding_5_application_embedding_into_salesforce/embedding_5_application_embedding_into_salesforce.md
+++ b/site/sigmaguides/src/embedding_5_application_embedding_into_salesforce/embedding_5_application_embedding_into_salesforce.md
@@ -159,6 +159,10 @@ public class SigmaEmbedClass {
                         
     // Append the Sigma embedding method to the url. For secure embedding, always use "userbacked":
         url += '&:mode=userbacked';
+
+    // Append the Sigma account type that you wish for each user to inherit during creation. In this example, we have an account
+    // type called 'Viewer' with viewer permissions:
+        url += '&:account_type=Viewer';
         
     // Append Sigma Team of user:
     // IMPORTANT: The embedded content (WB, Page or Viz) must be shared with the Team in Sigma or permission will be denied:


### PR DESCRIPTION
I found myself in a conversation with some folks from Druva, complaining that their salesforce embed users were being counted against their creator license count. It looks like (confirmed with Jon Avrach) that if someone doesn't specify the `:account_type=` param during creation, they'll default to Creator. Updating the docs here to be a little more verbose to prevent weird licensing conversations like what happened today with Druva, myself, and Stacey R

<img width="547" alt="image" src="https://github.com/sigmacomputing/sigmaquickstarts/assets/20668680/8e706bd2-c6f3-467d-afe1-700ff690f5b9">
