### PR TITLE
Updates to Snowflake Cost per Query and GA4 template Quickstarts

### DIFF
--- a/site/sigmaguides/src/google_analytics_4_template/google_analytics_4_template.md
+++ b/site/sigmaguides/src/google_analytics_4_template/google_analytics_4_template.md
@@ -58,7 +58,7 @@ Before configuring the Snowflake Connector for Google Analytics Raw Data (GARD),
 At a high level, the necessary actions in your Google account are
 <ol>
   <li>Migrate your Google Analytics from Universal Analytics to GA4.  This is done inside the GA platform.</li>
-  <li>Configure a BigQuery link for GA4 data.  This is done inside the GA platform and allows raw GA data to be dumped into a GCP project.</li>
+  <li>Configure a BigQuery link for GA4 data.  This is done inside the GA platform and allows raw GA data to be dumped into a GCP project.  Note that you should use the Daily export option.</li>
   <li>Configure a service account or OAuth authentication to allow Snowflake to read data from BigQuery storage.  This is done in the GCP platform.</li>
 </ol> 
 

--- a/site/sigmaguides/src/snowflake_cost_per_query_template/snowflake_cost_per_query_template.md
+++ b/site/sigmaguides/src/snowflake_cost_per_query_template/snowflake_cost_per_query_template.md
@@ -84,7 +84,7 @@ Duration: 5
 
 Another way to create the `query_history_enriched` table is by running the attached SQL script in your Snowflake account.
 
-[Download the SQL script here!](https://sigma-quickstarts-main.s3.us-west-1.amazonaws.com/templates/query_history_enriched.sql)
+[Download the SQL script here!](https://github.com/sigmacomputing/quickstarts-public/blob/main/snowflake_cost_per_query_template/query_history_enriched.sql)
 
 **The script requires you to specify a few parameters:**
 <ul>


### PR DESCRIPTION
Made 2 small changes:
1. In the Google Analytcs 4 Template quickstart, I added detail on which export method to use when linking GA with BQ (daily, not streaming).

2. In the Snowflake Cost per Query quickstart, I changed the location of the setup SQL script to the file in quickstarts-public