### PR TITLE
Fix various grammar/typos in "Fundamentals" documents

### DIFF
--- a/site/sigmaguides/src/Fundamentals 1: Getting Around_v2/Fundamentals 1: Getting Around.md
+++ b/site/sigmaguides/src/Fundamentals 1: Getting Around_v2/Fundamentals 1: Getting Around.md
@@ -174,7 +174,7 @@ Once you open a different page, you may notice the back arrow next to the Sigma 
 <strong>IMPORTANT:</strong><br> The second thing to remember is that we built Sigma from day one on a modern cloud architecture. This allows us to add new functionality very quickly!
 </aside>
 
-If at anytime you notice an item labeled **BETA**, that means that the feature is mature enough to be included for all customers to evaluate while we finalize it's release.
+If at anytime you notice an item labeled **BETA**, that means that the feature is mature enough to be included for all customers to evaluate while we finalize its release.
 
 For example, at the time of this QuickStart, data models carried the beta tag:
 
@@ -568,7 +568,7 @@ There are three default account types: `Lite`, `Essential` and `Pro`.
   <li><strong>Pro:</strong> allows the original workbook to be altered as if they were the owner.</li>
 </ul>
 
-As an `administrator`, we can the default account types by navigating to `Administration` > `Account Types`.
+As an `administrator`, we can see these default account types by navigating to `Administration` > `Account Types`.
 
 Here we see the three default types, description and can also create a new custom account type:
 

--- a/site/sigmaguides/src/Fundamentals 2: Working with Tables-v2/Fundamentals 2: Working with Tables.md
+++ b/site/sigmaguides/src/Fundamentals 2: Working with Tables-v2/Fundamentals 2: Working with Tables.md
@@ -200,7 +200,7 @@ Your table should now look similar to this:
 <strong>NOTE:</strong><br> Negative values for Profit and Profit Margin indicates items sold at a loss.
 </aside>
 
-Some of these functions have been pretty easy, but Sigma is capable of performing the most commonly used functions available in excel/google sheets or SQL. 
+Some of these functions have been pretty easy, but Sigma is capable of performing the most commonly used functions available in Excel/Google Sheets or SQL. 
 
 We will get into some more advanced functions later, but you can always check out the complete list by clicking the `Help` button <img src="assets/calculatedcols4.png" width="25"/> in the lower right hand corner and selecting [Function Index](https://help.sigmacomputing.com/docs/popular-functions)
 

--- a/site/sigmaguides/src/Fundamentals 4: Working with Pivot Tables-v2/Fundamentals 4: Working with Pivot Tables.md
+++ b/site/sigmaguides/src/Fundamentals 4: Working with Pivot Tables-v2/Fundamentals 4: Working with Pivot Tables.md
@@ -121,7 +121,7 @@ DateTrunc("year", [Date])
 
 <img src="assets/pivot2_6.png" width="800"/>
 
-Sigma has also provided all the most common functions (ie: write the function for you!) as menu options off of a column, so you could have just applied that too:
+Sigma has also provided all the most common functions (i.e., write the function for you!) as menu options off of a column, so you could have just applied that too:
 
 <img src="assets/pivot2_7.png" width="600"/>
 

--- a/site/sigmaguides/src/Fundamentals 6: Controls-v2/fundamentals_6_controls_v2.md
+++ b/site/sigmaguides/src/Fundamentals 6: Controls-v2/fundamentals_6_controls_v2.md
@@ -164,7 +164,7 @@ We checked and found there are some orders sold a big losses, so we set the mini
 Also set the `Control ID` for `Profit` to `profit-slider`.
 
 <aside class="positive">
-<strong>IMPORTANT:</strong><br> Be sure to pay attention to the "Control ID" used for each control. They need to be unique and Sigma will ensure this, of you don't. We can reference the current value that a control is set to by referring to it's Control ID. This can be useful in a variety of use cases, especially in formulas.
+<strong>IMPORTANT:</strong><br> Be sure to pay attention to the "Control ID" used for each control. They need to be unique and Sigma will ensure this if you don't. We can reference the current value that a control is set to by referring to it's Control ID. This can be useful in a variety of use cases, especially in formulas.
 </aside>
 
 Now adjust the `Profit` slider to be around $6500. These are are target high-value customers:
@@ -449,7 +449,7 @@ Add a `Table` to the page, using the `PLUGS_DATA` table on the `DATA` page as th
 For this exercise, lets reduce the available data down so that refresh is as fast as possible.
 
 <aside class="positive">
-<strong>IMPORTANT:</strong><br> Sigma is optimized for cloud operations. Sigma trial instances use a Snowflake x-small warehouse, so while performance is still good for our 4.5+ record PLUGS_DATA table, the cloud compute size will "bottle-neck" our performance to some extent. 
+<strong>IMPORTANT:</strong><br> Sigma is optimized for cloud operations. Sigma trial instances use a Snowflake x-small warehouse, so while performance is still good for our 4.5M+ record PLUGS_DATA table, the cloud compute size will "bottle-neck" our performance to some extent. 
 
 Reducing the size of the data will allow us to move as fast as possible in our demonstration. 
 

--- a/site/sigmaguides/src/Fundamentals 8: Beyond The Basics-1-v2/Fundamentals 8: Beyond The Basics-1.md
+++ b/site/sigmaguides/src/Fundamentals 8: Beyond The Basics-1-v2/Fundamentals 8: Beyond The Basics-1.md
@@ -116,7 +116,7 @@ We are shown the updated `lineage` and have to opportunity to go back and make a
 Before we click `Done`, notice that the row count still has the expected value (around 4.5 million rows) that we had at the start. This makes sense since the base table is retail sales, each sale having a customer and a store. 
 
 <aside class="positive">
-<strong>IMPORTANT:</strong><br> Paying attention to how your joins effects row count can be a clue to potential problems in join types, join keys or other configuration issues. 
+<strong>IMPORTANT:</strong><br> Paying attention to how your join affects row count can be a clue to potential problems in join types, join keys or other configuration issues. 
 </aside>
 
 Click `Done`.
@@ -455,7 +455,7 @@ Rename the new table `Q1 Sales Detail`.
 
 Click `Publish`.
 
-### Linage
+### Lineage
 As workbooks become more complex, it can be really useful to see graphically see how the data is sourced. 
 
 Sigma provides this `Lineage` automatically and it is accessed by clicking the icon in the lower corner of the workbook:
@@ -507,7 +507,7 @@ We can easily sum `Sales` and also select to compare the `Date` columns value to
 Also check the `Output` boxes on for `Difference`, `% difference` and `Value`. This will create columns for each of these options.
 
 <aside class="negative">
-<strong>NOTE:</strong><br> Columns that are "created" in this way in Sigma are added by making calculations in your local browser. They are not stored in your cloud data warehouse or effect your source data in any way.
+<strong>NOTE:</strong><br> Columns that are "created" in this way in Sigma are added by making calculations in your local browser. They are not stored in your cloud data warehouse and do not affect your source data in any way.
 </aside>
 
 Click `Done`.
@@ -529,7 +529,7 @@ The Sigma function [DateLookback](https://help.sigmacomputing.com/docs/datelookb
 
 <img src="assets/dm_47.png" width="800"/>
 
-If you have need more information on functions in Sigma, we have included a link for your convenience:
+If you need more information on functions in Sigma, we have included a link for your convenience:
 
 <img src="assets/dm_48.png" width="800"/>
 
@@ -700,7 +700,7 @@ Add a new column in the `VALUES` section of `PIVOT COLUMNS` and set it's formula
 Sum([Sales]) / [Sum of Sales (Grand Total)]
 ```
 
-Rename the new column `Contribution` and set it's format to `Percentage`:
+Rename the new column `Contribution` and set its format to `Percentage`:
 
 <img src="assets/dm_66.png" width="800"/>
 


### PR DESCRIPTION
I noticed these when learning about Sigma:

* Fundmentals 1
  * "it's release" (wrong "its")
  * "we can the default account types" (added missing word)
* Fundmentals 2
  * "excel/google sheets" (capitalization)
* Fundmentals 4
  * "(ie: write the function for you!)" (punctuation for "i.e." abbreviation)
  * "4.5+ record PLUGS_DATA table" (the table contains 4.5 million records, not just 4.5)
* Fundmentals 6
  * "ensure this, of you don't" (misspelling)
* Fundmentals 8
  * "joins effects" (wrong "affect"; subject-verb agreement)
  * "Linage" (misspelling)
  * "They are not stored in your cloud data warehouse or effect your source data in any way." (wrong "affect"; parallel structure)
  * "you have need more information" (unnecessary word)
  * "it's format" (wrong its)