### PR TITLE
Fix typo in 'Getting Around' section

### DIFF
--- a/site/sigmaguides/src/Fundamentals 1: Getting Around - v3/Fundamentals 1: Getting Around v3.md
+++ b/site/sigmaguides/src/Fundamentals 1: Getting Around - v3/Fundamentals 1: Getting Around v3.md
@@ -608,7 +608,7 @@ On the `F_SALES` table, open its menu and select `Move to` > `Dashboard`:
 Click `Publish`.
 
 ### Use a page for instructions or useful information
-Creating a dedicated workbook page to to inform and assist users who are looking at the workbook is a best practice.
+Creating a dedicated workbook page to inform and assist users who are looking at the workbook is a best practice.
 
 As an example, the image below is the `Home` page from the `Financial Services: Portfolio Risk Modeling` workbook. It has informative text along with some navigation buttons along the top:
 


### PR DESCRIPTION
This pull request fixes a minor typo in the "Fundamentals 01: Getting Around – Section 7" of the Sigma Quickstart documentation. The phrase:

"Creating a dedicated workbook page to to inform and..."
contained a duplicated "to". This has been corrected to:

"Creating a dedicated workbook page to inform and..."
This is a small change, but it improves readability and professionalism of the documentation.

Fixes: #422