### PR TITLE
Use local claat fork in deploy workflows

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -18,7 +18,7 @@ jobs:
       - run: |
           export GOPATH="$HOME/go/"
           export PATH=$PATH:$GOPATH/bin
-          go install github.com/googlecodelabs/tools/claat@latest
+          (cd claat && go install .)
           cd site && npm install && npm run deploy
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -12,5 +12,5 @@ jobs:
       - run: |
           export GOPATH="$HOME/go/"
           export PATH=$PATH:$GOPATH/bin
-          go install github.com/googlecodelabs/tools/claat@latest
+          (cd claat && go install .)
           cd site && npm install && npm run deploy


### PR DESCRIPTION
The workflows were installing claat from github.com/googlecodelabs/tools/claat@latest, which bypasses the local claat fork in ./claat that contains the LocalVideoNode patch for embedded mp4 videos. Switch to `go install .` from the claat/ directory so deploys use the patched parser/renderer.