### PR TITLE
Hide Connect Snowflake Intelligence to Sigma Workbook QS

### DIFF
--- a/site/sigmaguides/src/partners_snowflake_intelligence/partners_snowflake_intelligence.md
+++ b/site/sigmaguides/src/partners_snowflake_intelligence/partners_snowflake_intelligence.md
@@ -3,10 +3,10 @@ id: partners_snowflake_intelligence
 summary: partners_snowflake_intelligence
 categories: aiapps
 environments: web
-status: Published
+status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags: Default
-lastUpdated: 2026-05-10
+tags:
+lastUpdated: 2026-06-10
 
 # Connect Snowflake Intelligence to Sigma Workbook
 


### PR DESCRIPTION
This QS is superseded by the public-beta Sigma agents flow, which uses Snowflake Cortex Agents as warehouse tools inside Sigma agents rather than the older Snowflake Intelligence connection pattern. Switching the QS status to Hidden so it no longer appears in the public catalog.

The two new QSs that replace this content:
- Unlocking Insights from Unstructured Text with a Sigma Agent
- Build Conversational AI Apps with Chat Elements and Snowflake Cortex