### PR TITLE
Migration QS family sweep: align Overview sections to canonical shape

### DIFF
--- a/site/app/styles/_overrides.scss
+++ b/site/app/styles/_overrides.scss
@@ -30,6 +30,7 @@ $color-developers: #3F51B5;
 $color-embedding: #06dbf7;
 $color-firstfridayfeatures: #1F91F2;
 $color-fundamentals: #FFA726;
+$color-migrations: #FF6B35;
 $color-security: #f70606;
 $color-tables: #FBC02D;
 $color-use-cases: #7E57C2;
@@ -43,6 +44,7 @@ $icon-developers: 'developers.svg';
 $icon-embedding: 'embedding.svg';
 $icon-firstfridayfeatures: 'administration.svg';
 $icon-fundamentals: 'Solutions_MarkAnal.svg';
+$icon-migrations: 'developers.svg';
 $icon-security: 'security.svg';
 $icon-tables: 'tables.svg';
 $icon-use-cases: 'use-cases.svg';
@@ -56,6 +58,7 @@ $icon-templates: 'workbook-template.svg';
 @include codelab-card(['embedding'], $color-embedding, $icon-embedding);
 @include codelab-card(['firstfridayfeatures'], $color-firstfridayfeatures, $icon-firstfridayfeatures);
 @include codelab-card(['fundamentals'], $color-fundamentals, $icon-fundamentals);
+@include codelab-card(['migrations'], $color-migrations, $icon-migrations);
 @include codelab-card(['security'], $color-security, $icon-security);
 @include codelab-card(['tables'], $color-tables, $icon-tables);
 @include codelab-card(['use-cases'], $color-use-cases, $icon-use-cases);
@@ -66,6 +69,7 @@ $icon-templates: 'workbook-template.svg';
 // Special override for dark category bars - white text
 .administration-bar,
 .functions-bar,
+.migrations-bar,
 .partners-bar,
 .use-cases-bar,
 .security-bar,
@@ -83,6 +87,7 @@ Embedding
 First Friday Features
 Functions
 Fundamentals
+Migrations
 Partners
 Security
 Tables (include pivot and input tables for now)

--- a/site/app/views/default/index.html
+++ b/site/app/views/default/index.html
@@ -1217,6 +1217,7 @@
                         <option value="embedding">Embedding</option>
                         <option value="functions">Functions</option>
                         <option value="fundamentals">Fundamentals for New Users</option>
+                        <option value="migrations">Migrations</option>
                         <option value="partners">Partners</option>
                         <option value="security">Security</option>
                         <option value="tables">Tables</option>

--- a/site/sigmaguides/src/aiapps_gong_call_analysis/aiapps_gong_call_analysis.md
+++ b/site/sigmaguides/src/aiapps_gong_call_analysis/aiapps_gong_call_analysis.md
@@ -6,7 +6,7 @@ environments: web
 status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags: default
-lastUpdated: 2026-06-26
+lastUpdated: 2026-05-26
 
 # Unlocking Insights from Unstructured Text with a Sigma Agent
 

--- a/site/sigmaguides/src/developers_migrating_from_microstrategy_made_easy/developers_migrating_from_microstrategy_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_microstrategy_made_easy/developers_migrating_from_microstrategy_made_easy.md
@@ -30,16 +30,22 @@ For the demonstration, we'll convert a MicroStrategy dossier called `Retail Insi
 <strong>WHY IT MATTERS:</strong><br> The skill runs the whole conversion — extract, translate, build, verify — and finishes with a documented parity check. The result is a working Sigma workbook on the warehouse plus the report that proves it matches the MicroStrategy source, instead of a rebuilt-by-hand workbook you have to spot-check yourself.
 </aside>
 
+### What else this enables
+
+A pure lift-and-shift is the floor, not the ceiling. The same skill family supports three follow-on moves that turn a migration into an upgrade:
+
+- **Dedup before you migrate.** Most BI estates carry years of dashboard sprawl — multiple near-identical dashboards built by different teams over time. The assessment skill flags dashboards that are roughly 90% the same and recommends merging them before conversion. You move 200 dashboards instead of 800, and every downstream conversation is simpler. Pair this with the usage data the assessment pulls (who views what, how often) and you can confidently retire cold content rather than carry it forward.
+
+- **Enhance, don't just translate.** Many "dashboards" in legacy tools are really input-driven workflows in disguise — a dashboard whose data is refreshed by uploading a CSV each morning is actually a forecasting app waiting to happen. After the lift-and-shift, the skill can suggest replacing those patterns with native Sigma constructs: input tables for write-back, Sigma Assistant for natural-language analysis, scheduled agents for routine summaries. The result isn't "the old dashboard, in a new tool" — it's "the workflow, finally done right."
+
+- **Audit your source as a side effect.** The parity check that closes the run isn't just a confidence test on the migration — it's a fresh pair of eyes on the source platform's math. Sigma customers have caught multi-year calculation errors during their first migration run because the parity gate flagged a Sigma vs source mismatch and the source turned out to be wrong. Plan the migration as your final audit of the legacy system.
+
 <aside class="negative">
 <strong>NOTE:</strong><br> The migration is one-directional — MicroStrategy is the source, Sigma is the target. Sigma reads the warehouse live, so the conversion's accuracy depends on the warehouse tables behind your MicroStrategy schema being reachable from a Sigma connection. The skill extracts the classic-schema semantic model (attributes / facts / metrics / logical tables) over the MSTR REST API and reconciles those objects back to the underlying warehouse columns. Parity is checked against MicroStrategy's own report results via the API, so any caching or Intelligent Cube staleness surfaces as an explicit row-level diff rather than getting buried.
 </aside>
 
-<aside class="positive">
-<strong>ABOUT THE SKILL CODE:</strong><br> The skill code used in this QuickStart is vendored into <code>sigmacomputing/quickstarts-public</code> for a stable reader experience — the version you clone matches what's captured in the screenshots and outputs below. The upstream skill at <a href="https://github.com/twells89/sigma-migration-skills">twells89/sigma-migration-skills</a> is actively evolving with new converter capabilities, bug fixes, and additional source-tool support. If you want the latest improvements after completing the QS, point your skill symlink at the upstream repo instead.
-</aside>
-
 <aside class="negative">
-<strong>AI MODEL DIFFERENCES:</strong><br> Depending on the AI model and Claude Code version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
+<strong>AI MODEL DIFFERENCES:</strong><br> Depending on which AI, model, and version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
 </aside>
 
 ### Target Audience

--- a/site/sigmaguides/src/developers_migrating_from_microstrategy_made_easy/developers_migrating_from_microstrategy_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_microstrategy_made_easy/developers_migrating_from_microstrategy_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_from_microstrategy_made_easy
 summary: developers_migrating_from_microstrategy_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags:
-lastUpdated: 2026-0-23
+lastUpdated: 2026-07-01
 
 # Migrating From MicroStrategy Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_from_microstrategy_made_easy/developers_migrating_from_microstrategy_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_microstrategy_made_easy/developers_migrating_from_microstrategy_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_from_microstrategy_made_easy
 summary: developers_migrating_from_microstrategy_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags:
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From MicroStrategy Made Easy

--- a/site/sigmaguides/src/developers_migrating_from_quicksight_made_easy/developers_migrating_from_quicksight_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_quicksight_made_easy/developers_migrating_from_quicksight_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_from_quicksight_made_easy
 summary: developers_migrating_from_quicksight_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags:
-lastUpdated: 2026-06-25
+lastUpdated: 2026-07-01
 
 # Migrating From AWS QuickSight Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_from_quicksight_made_easy/developers_migrating_from_quicksight_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_quicksight_made_easy/developers_migrating_from_quicksight_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_from_quicksight_made_easy
 summary: developers_migrating_from_quicksight_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags:
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From AWS QuickSight Made Easy

--- a/site/sigmaguides/src/developers_migrating_from_tableau_made_easy/developers_migrating_from_tableau_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_tableau_made_easy/developers_migrating_from_tableau_made_easy.md
@@ -27,16 +27,22 @@ For the demonstration, we'll run the skill end-to-end against the built-in `Supe
 <strong>WHY IT MATTERS:</strong><br> The skill runs the whole conversion — discover, model, build, verify — and finishes with a documented parity check. The result is a working Sigma workbook on the warehouse plus the report that proves it matches the Tableau source, instead of a rebuilt-by-hand dashboard you have to spot-check yourself.
 </aside>
 
+### What else this enables
+
+A pure lift-and-shift is the floor, not the ceiling. The same skill family supports three follow-on moves that turn a migration into an upgrade:
+
+- **Dedup before you migrate.** Most BI estates carry years of dashboard sprawl — multiple near-identical dashboards built by different teams over time. The assessment skill flags dashboards that are roughly 90% the same and recommends merging them before conversion. You move 200 dashboards instead of 800, and every downstream conversation is simpler. Pair this with the usage data the assessment pulls (who views what, how often) and you can confidently retire cold content rather than carry it forward.
+
+- **Enhance, don't just translate.** Many "dashboards" in legacy tools are really input-driven workflows in disguise — a dashboard whose data is refreshed by uploading a CSV each morning is actually a forecasting app waiting to happen. After the lift-and-shift, the skill can suggest replacing those patterns with native Sigma constructs: input tables for write-back, Sigma Assistant for natural-language analysis, scheduled agents for routine summaries. The result isn't "the old dashboard, in a new tool" — it's "the workflow, finally done right."
+
+- **Audit your source as a side effect.** The parity check that closes the run isn't just a confidence test on the migration — it's a fresh pair of eyes on the source platform's math. Sigma customers have caught multi-year calculation errors during their first migration run because the parity gate flagged a Sigma vs source mismatch and the source turned out to be wrong. Plan the migration as your final audit of the legacy system.
+
 <aside class="negative">
 <strong>NOTE:</strong><br> The migration is one-directional — Tableau is the source, Sigma is the target. Sigma reads the warehouse live; Tableau may be reading a frozen <code>.hyper</code> extract, so live-vs-extract drift is expected. The skill handles it via <code>--extract-mode</code> parity in <code>Verifying Data Parity</code>.
 </aside>
 
-<aside class="positive">
-<strong>ABOUT THE SKILL CODE:</strong><br> The skill code used in this QuickStart is vendored into <code>sigmacomputing/quickstarts-public</code> for a stable reader experience — the version you clone matches what's captured in the screenshots and outputs below. The upstream skill at <a href="https://github.com/twells89/sigma-migration-skills">twells89/sigma-migration-skills</a> is actively evolving with new converter capabilities, bug fixes, and additional source-tool support. If you want the latest improvements after completing the QS, point your skill symlink at the upstream repo instead.
-</aside>
-
 <aside class="negative">
-<strong>AI MODEL DIFFERENCES:</strong><br> Depending on the AI model and Claude Code version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
+<strong>AI MODEL DIFFERENCES:</strong><br> Depending on which AI, model, and version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
 </aside>
 
 ### Target Audience

--- a/site/sigmaguides/src/developers_migrating_from_tableau_made_easy/developers_migrating_from_tableau_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_tableau_made_easy/developers_migrating_from_tableau_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_from_tableau_made_easy
 summary: developers_migrating_from_tableau_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags: 
-lastUpdated: 2026-06-20
+lastUpdated: 2026-07-01
 
 # Migrating From Tableau Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_from_tableau_made_easy/developers_migrating_from_tableau_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_tableau_made_easy/developers_migrating_from_tableau_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_from_tableau_made_easy
 summary: developers_migrating_from_tableau_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags: 
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From Tableau Made Easy

--- a/site/sigmaguides/src/developers_migrating_from_thoughtspot_made_easy/developers_migrating_from_thoughtspot_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_thoughtspot_made_easy/developers_migrating_from_thoughtspot_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_from_thoughtspot_made_easy
 summary: developers_migrating_from_thoughtspot_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags:
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From ThoughtSpot Made Easy

--- a/site/sigmaguides/src/developers_migrating_from_thoughtspot_made_easy/developers_migrating_from_thoughtspot_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_thoughtspot_made_easy/developers_migrating_from_thoughtspot_made_easy.md
@@ -29,16 +29,22 @@ You'll see the TML each phase produces, the converter's breakdown of how each se
 <strong>WHY IT MATTERS:</strong><br> The skill runs the whole conversion — extract, translate, build, verify — and finishes with a documented parity check. The result is a working Sigma workbook on the warehouse plus the report that proves it matches the ThoughtSpot source, instead of a rebuilt-by-hand workbook you have to spot-check yourself.
 </aside>
 
+### What else this enables
+
+A pure lift-and-shift is the floor, not the ceiling. The same skill family supports three follow-on moves that turn a migration into an upgrade:
+
+- **Dedup before you migrate.** Most BI estates carry years of dashboard sprawl — multiple near-identical dashboards built by different teams over time. The assessment skill flags dashboards that are roughly 90% the same and recommends merging them before conversion. You move 200 dashboards instead of 800, and every downstream conversation is simpler. Pair this with the usage data the assessment pulls (who views what, how often) and you can confidently retire cold content rather than carry it forward.
+
+- **Enhance, don't just translate.** Many "dashboards" in legacy tools are really input-driven workflows in disguise — a dashboard whose data is refreshed by uploading a CSV each morning is actually a forecasting app waiting to happen. After the lift-and-shift, the skill can suggest replacing those patterns with native Sigma constructs: input tables for write-back, Sigma Assistant for natural-language analysis, scheduled agents for routine summaries. The result isn't "the old dashboard, in a new tool" — it's "the workflow, finally done right."
+
+- **Audit your source as a side effect.** The parity check that closes the run isn't just a confidence test on the migration — it's a fresh pair of eyes on the source platform's math. Sigma customers have caught multi-year calculation errors during their first migration run because the parity gate flagged a Sigma vs source mismatch and the source turned out to be wrong. Plan the migration as your final audit of the legacy system.
+
 <aside class="negative">
 <strong>NOTE:</strong><br> The migration is one-directional — ThoughtSpot is the source, Sigma is the target. Sigma reads the warehouse live, so the ThoughtSpot model you're migrating needs to point at warehouse tables (an Embrace model) or you'll need to extract its data to your warehouse first. ThoughtSpot's bundled <code>(Sample)</code> worksheets typically read from the in-memory <code>Falcon</code> engine with no warehouse table behind them — for those, the skill ships a <code>ts_lib.searchdata()</code> helper that wraps the REST <code>searchdata</code> endpoint to land the data in a warehouse before conversion. The skill handles parity by running the comparison through ThoughtSpot's own <code>searchdata</code> API, so the numbers are always checked against what ThoughtSpot itself returns.
 </aside>
 
-<aside class="positive">
-<strong>ABOUT THE SKILL CODE:</strong><br> The skill code used in this QuickStart is vendored into <code>sigmacomputing/quickstarts-public</code> for a stable reader experience — the version you clone matches what's captured in the screenshots and outputs below. The upstream skill at <a href="https://github.com/twells89/sigma-migration-skills">twells89/sigma-migration-skills</a> is actively evolving with new converter capabilities, bug fixes, and additional source-tool support. If you want the latest improvements after completing the QS, point your skill symlink at the upstream repo instead.
-</aside>
-
 <aside class="negative">
-<strong>AI MODEL DIFFERENCES:</strong><br> Depending on the AI model and Claude Code version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
+<strong>AI MODEL DIFFERENCES:</strong><br> Depending on which AI, model, and version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
 </aside>
 
 ### Target Audience

--- a/site/sigmaguides/src/developers_migrating_from_thoughtspot_made_easy/developers_migrating_from_thoughtspot_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_from_thoughtspot_made_easy/developers_migrating_from_thoughtspot_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_from_thoughtspot_made_easy
 summary: developers_migrating_from_thoughtspot_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags:
-lastUpdated: 2026-06-17
+lastUpdated: 2026-07-01
 
 # Migrating From ThoughtSpot Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_looker_made_easy/developers_migrating_looker_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_looker_made_easy/developers_migrating_looker_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_looker_made_easy
 summary: developers_migrating_looker_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags:
-lastUpdated: 2026-07-20
+lastUpdated: 2026-07-01
 
 # Migrating From Looker Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_looker_made_easy/developers_migrating_looker_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_looker_made_easy/developers_migrating_looker_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_looker_made_easy
 summary: developers_migrating_looker_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags:
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From Looker Made Easy

--- a/site/sigmaguides/src/developers_migrating_looker_made_easy/developers_migrating_looker_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_looker_made_easy/developers_migrating_looker_made_easy.md
@@ -31,16 +31,22 @@ You'll see the discovery artifacts each phase produces, the converter's breakdow
 <strong>WHY IT MATTERS:</strong><br> The skill runs the whole conversion — discover, translate, build, verify — and finishes with a documented parity check. The result is a working Sigma workbook on the warehouse plus the report that proves it matches the Looker source, instead of a rebuilt-by-hand workbook you have to spot-check yourself.
 </aside>
 
+### What else this enables
+
+A pure lift-and-shift is the floor, not the ceiling. The same skill family supports three follow-on moves that turn a migration into an upgrade:
+
+- **Dedup before you migrate.** Most BI estates carry years of dashboard sprawl — multiple near-identical dashboards built by different teams over time. The assessment skill flags dashboards that are roughly 90% the same and recommends merging them before conversion. You move 200 dashboards instead of 800, and every downstream conversation is simpler. Pair this with the usage data the assessment pulls (who views what, how often) and you can confidently retire cold content rather than carry it forward.
+
+- **Enhance, don't just translate.** Many "dashboards" in legacy tools are really input-driven workflows in disguise — a dashboard whose data is refreshed by uploading a CSV each morning is actually a forecasting app waiting to happen. After the lift-and-shift, the skill can suggest replacing those patterns with native Sigma constructs: input tables for write-back, Sigma Assistant for natural-language analysis, scheduled agents for routine summaries. The result isn't "the old dashboard, in a new tool" — it's "the workflow, finally done right."
+
+- **Audit your source as a side effect.** The parity check that closes the run isn't just a confidence test on the migration — it's a fresh pair of eyes on the source platform's math. Sigma customers have caught multi-year calculation errors during their first migration run because the parity gate flagged a Sigma vs source mismatch and the source turned out to be wrong. Plan the migration as your final audit of the legacy system.
+
 <aside class="negative">
 <strong>NOTE:</strong><br> The migration is one-directional — Looker is the source, Sigma is the target. Sigma reads the warehouse live, so the conversion's accuracy depends on the warehouse tables behind your Looker model being reachable from a Sigma connection. The skill reads the LookML project files (model + views) from a local clone of your Looker project's Git repo and reconciles the LookML view names back to the underlying warehouse columns. Parity is checked against Looker's own query results via the API, so any cache or PDT staleness surfaces as an explicit row-level diff rather than getting buried.
 </aside>
 
-<aside class="positive">
-<strong>ABOUT THE SKILL CODE:</strong><br> The skill code used in this QuickStart is vendored into <code>sigmacomputing/quickstarts-public</code> for a stable reader experience — the version you clone matches what's captured in the screenshots and outputs below. The upstream skill at <a href="https://github.com/twells89/sigma-migration-skills">twells89/sigma-migration-skills</a> is actively evolving with new converter capabilities, bug fixes, and additional source-tool support. If you want the latest improvements after completing the QS, point your skill symlink at the upstream repo instead.
-</aside>
-
 <aside class="negative">
-<strong>AI MODEL DIFFERENCES:</strong><br> Depending on the AI model and Claude Code version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
+<strong>AI MODEL DIFFERENCES:</strong><br> Depending on which AI, model, and version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
 </aside>
 
 ### Target Audience

--- a/site/sigmaguides/src/developers_migrating_power_bi_made_easy/developers_migrating_power_bi_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_power_bi_made_easy/developers_migrating_power_bi_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_power_bi_made_easy
 summary: developers_migrating_power_bi_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags:
-lastUpdated: 2026-06-15
+lastUpdated: 2026-07-01
 
 # Migrating From Power BI Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_power_bi_made_easy/developers_migrating_power_bi_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_power_bi_made_easy/developers_migrating_power_bi_made_easy.md
@@ -27,16 +27,22 @@ For the demonstration, we'll run the skill end-to-end against a sample Power BI 
 <strong>WHY IT MATTERS:</strong><br> The skill runs the whole conversion — extract, translate, build, verify — and finishes with a documented parity check. The result is a working Sigma workbook on the warehouse plus the report that proves it matches the Power BI source, instead of a rebuilt-by-hand report you have to spot-check yourself.
 </aside>
 
+### What else this enables
+
+A pure lift-and-shift is the floor, not the ceiling. The same skill family supports three follow-on moves that turn a migration into an upgrade:
+
+- **Dedup before you migrate.** Most BI estates carry years of dashboard sprawl — multiple near-identical dashboards built by different teams over time. The assessment skill flags dashboards that are roughly 90% the same and recommends merging them before conversion. You move 200 dashboards instead of 800, and every downstream conversation is simpler. Pair this with the usage data the assessment pulls (who views what, how often) and you can confidently retire cold content rather than carry it forward.
+
+- **Enhance, don't just translate.** Many "dashboards" in legacy tools are really input-driven workflows in disguise — a dashboard whose data is refreshed by uploading a CSV each morning is actually a forecasting app waiting to happen. After the lift-and-shift, the skill can suggest replacing those patterns with native Sigma constructs: input tables for write-back, Sigma Assistant for natural-language analysis, scheduled agents for routine summaries. The result isn't "the old dashboard, in a new tool" — it's "the workflow, finally done right."
+
+- **Audit your source as a side effect.** The parity check that closes the run isn't just a confidence test on the migration — it's a fresh pair of eyes on the source platform's math. Sigma customers have caught multi-year calculation errors during their first migration run because the parity gate flagged a Sigma vs source mismatch and the source turned out to be wrong. Plan the migration as your final audit of the legacy system.
+
 <aside class="negative">
 <strong>NOTE:</strong><br> The migration is one-directional — Power BI is the source, Sigma is the target. Sigma reads the warehouse live; Power BI may be reading an in-memory <code>Import</code> model rather than the warehouse directly, so live-vs-import drift is expected. The skill handles it by running the parity check through Power BI's own <code>executeQueries</code> API, so the comparison is always against what Power BI itself returns.
 </aside>
 
-<aside class="positive">
-<strong>ABOUT THE SKILL CODE:</strong><br> The skill code used in this QuickStart is vendored into <code>sigmacomputing/quickstarts-public</code> for a stable reader experience — the version you clone matches what's captured in the screenshots and outputs below. The upstream skill at <a href="https://github.com/twells89/sigma-migration-skills">twells89/sigma-migration-skills</a> is actively evolving with new converter capabilities, bug fixes, and additional source-tool support. If you want the latest improvements after completing the QS, point your skill symlink at the upstream repo instead.
-</aside>
-
 <aside class="negative">
-<strong>AI MODEL DIFFERENCES:</strong><br> Depending on the AI model and Claude Code version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
+<strong>AI MODEL DIFFERENCES:</strong><br> Depending on which AI, model, and version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
 </aside>
 
 ### Target Audience

--- a/site/sigmaguides/src/developers_migrating_power_bi_made_easy/developers_migrating_power_bi_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_power_bi_made_easy/developers_migrating_power_bi_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_power_bi_made_easy
 summary: developers_migrating_power_bi_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags:
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From Power BI Made Easy

--- a/site/sigmaguides/src/developers_migrating_qlik_made_easy/developers_migrating_qlik_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_qlik_made_easy/developers_migrating_qlik_made_easy.md
@@ -1,12 +1,12 @@
 author: pballai
 id: developers_migrating_qlik_made_easy
 summary: developers_migrating_qlik_made_easy
-categories: developers
+categories: migrations
 environments: web
 status: Hidden
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
 tags:
-lastUpdated: 2026-06-17
+lastUpdated: 2026-07-01
 
 # Migrating From Qlik Made Easy
 

--- a/site/sigmaguides/src/developers_migrating_qlik_made_easy/developers_migrating_qlik_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_qlik_made_easy/developers_migrating_qlik_made_easy.md
@@ -27,16 +27,22 @@ For the demonstration, we'll run the skill end-to-end against a Qlik app called 
 <strong>WHY IT MATTERS:</strong><br> The skill runs the whole conversion — discover, translate, build, verify — and finishes with a documented parity check. The result is a working Sigma workbook on the warehouse plus the report that proves it matches the Qlik source, instead of a rebuilt-by-hand workbook you have to spot-check yourself.
 </aside>
 
+### What else this enables
+
+A pure lift-and-shift is the floor, not the ceiling. The same skill family supports three follow-on moves that turn a migration into an upgrade:
+
+- **Dedup before you migrate.** Most BI estates carry years of dashboard sprawl — multiple near-identical dashboards built by different teams over time. The assessment skill flags dashboards that are roughly 90% the same and recommends merging them before conversion. You move 200 dashboards instead of 800, and every downstream conversation is simpler. Pair this with the usage data the assessment pulls (who views what, how often) and you can confidently retire cold content rather than carry it forward.
+
+- **Enhance, don't just translate.** Many "dashboards" in legacy tools are really input-driven workflows in disguise — a dashboard whose data is refreshed by uploading a CSV each morning is actually a forecasting app waiting to happen. After the lift-and-shift, the skill can suggest replacing those patterns with native Sigma constructs: input tables for write-back, Sigma Assistant for natural-language analysis, scheduled agents for routine summaries. The result isn't "the old dashboard, in a new tool" — it's "the workflow, finally done right."
+
+- **Audit your source as a side effect.** The parity check that closes the run isn't just a confidence test on the migration — it's a fresh pair of eyes on the source platform's math. Sigma customers have caught multi-year calculation errors during their first migration run because the parity gate flagged a Sigma vs source mismatch and the source turned out to be wrong. Plan the migration as your final audit of the legacy system.
+
 <aside class="negative">
 <strong>NOTE:</strong><br> The migration is one-directional — Qlik is the source, Sigma is the target. Sigma reads the warehouse live, so the conversion's accuracy depends on the warehouse tables behind your Qlik app being reachable from a Sigma connection. The skill reads the app's in-memory model via <code>qlik-cli</code> and reconciles Qlik's renamed table and field names back to the underlying warehouse columns. When the OAuth client has the script-read scope, it pulls the LOAD script directly; when it doesn't (the typical M2M default), the skill reconstructs the model from <code>qlik app meta</code> instead — same outcome either way. Parity is checked against the warehouse-resolved numbers, not Qlik's in-memory cache, so any cache drift surfaces as an explicit row-level diff rather than getting buried.
 </aside>
 
-<aside class="positive">
-<strong>ABOUT THE SKILL CODE:</strong><br> The skill code used in this QuickStart is vendored into <code>sigmacomputing/quickstarts-public</code> for a stable reader experience — the version you clone matches what's captured in the screenshots and outputs below. The upstream skill at <a href="https://github.com/twells89/sigma-migration-skills">twells89/sigma-migration-skills</a> is actively evolving with new converter capabilities, bug fixes, and additional source-tool support. If you want the latest improvements after completing the QS, point your skill symlink at the upstream repo instead.
-</aside>
-
 <aside class="negative">
-<strong>AI MODEL DIFFERENCES:</strong><br> Depending on the AI model and Claude Code version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
+<strong>AI MODEL DIFFERENCES:</strong><br> Depending on which AI, model, and version you're running, the exact prompt wording, option ordering, and intermediate messages may differ slightly from what's shown in this QuickStart. The substantive steps and decisions are the same — pick the option that matches the intent described, even if the label varies.
 </aside>
 
 ### Target Audience

--- a/site/sigmaguides/src/developers_migrating_qlik_made_easy/developers_migrating_qlik_made_easy.md
+++ b/site/sigmaguides/src/developers_migrating_qlik_made_easy/developers_migrating_qlik_made_easy.md
@@ -3,9 +3,9 @@ id: developers_migrating_qlik_made_easy
 summary: developers_migrating_qlik_made_easy
 categories: migrations
 environments: web
-status: Hidden
+status: Published
 feedback link: https://github.com/sigmacomputing/sigmaquickstarts/issues
-tags:
+tags: default
 lastUpdated: 2026-07-01
 
 # Migrating From Qlik Made Easy


### PR DESCRIPTION
## Summary
Two-part change preparing the migration QS family for a unified review pass.

### Part 1 — Overview sweep (6 QSes)
Propagates the Overview changes Phil piloted on the QuickSight QS to the other 6 migration QSes — **Power BI, Tableau, ThoughtSpot, Qlik, Looker, MicroStrategy**. Each gets three identical changes:

1. **Remove the \`ABOUT THE SKILL CODE\` aside.** The vendor-vs-upstream narrative is obsolete once TJ's repo moves to the in-progress Sigma-owned public repo.
2. **Broaden \`AI MODEL DIFFERENCES\` wording.** "Depending on the AI model and Claude Code version" → "Depending on which AI, model, and version" — drops Claude-Code-specificity so the QS reads correctly for Cursor, Cortex Code, and other coding agents.
3. **Add \`### What else this enables\` section after the \`WHY IT MATTERS\` aside.** Three bullets:
   - **Dedup before you migrate** (assessment skill flags ~90% duplicates)
   - **Enhance, don't just translate** (input tables, Sigma Assistant, scheduled agents)
   - **Audit your source as a side effect** (parity gate catches multi-year calc errors)

Wording is verbatim across the family — pulled from the TJ + CEO migration messaging Phil shared on 2026-06-25.

### Part 2 — Migrations category creation + review-pass prep (all 7 QSes)
- **lastUpdated → 2026-07-01** across all 7 migration QSes (Power BI, Tableau, ThoughtSpot, Qlik, Looker, MicroStrategy, QuickSight). Lets Phil review the family in one pass.
- **New "Migrations" category** added in \`_overrides.scss\`:
  - Color: \`#FF6B35\` (vibrant orange-red — distinct from fundamentals' softer orange and all other category colors).
  - Icon: \`developers.svg\` (reused for now since the family targets the same developer audience).
  - Added to the dark-bg white-text override list.
- **All 7 QSes switched** from \`categories: developers\` → \`categories: migrations\`.

Cards in the library will now render with an orange-red **MIGRATIONS** badge instead of the blue **DEVELOPERS** one.

## Out of scope
- **Install and Configure the Skill section changes** (clone URL, sparse-checkout, symlink targets). Those wait until TJ's new Sigma-owned public repo lands, then we touch every QS again with the new clone instructions.
- **Section reorder** (moving \`### Sample dashboard\` below \`### What else this enables\`). The 5 non-MSTR QSes don't have an explicit \`### Sample dashboard\` heading; reordering inline content would be a deeper structural change than this sweep targets.

## Files changed
**Markdown (7):**
- \`developers_migrating_power_bi_made_easy.md\`
- \`developers_migrating_from_tableau_made_easy.md\`
- \`developers_migrating_from_thoughtspot_made_easy.md\`
- \`developers_migrating_qlik_made_easy.md\`
- \`developers_migrating_looker_made_easy.md\`
- \`developers_migrating_from_microstrategy_made_easy.md\`
- \`developers_migrating_from_quicksight_made_easy.md\` (lastUpdated + category only — Overview already at canonical)

**Styles (1):**
- \`app/styles/_overrides.scss\` — new \`migrations\` category

🤖 Generated with [Claude Code](https://claude.com/claude-code)