### PR TITLE
Replace Google Analytics with PostHog

### DIFF
--- a/claat/render/template.html
+++ b/claat/render/template.html
@@ -26,6 +26,17 @@ the License.
     })(window,document,'script','dataLayer','GTM-5DNFBHR');
   </script>
   <!-- End Google Tag Manager -->
+  <!-- PostHog Analytics -->
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+    posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+      api_host: 'https://us.i.posthog.com',
+      person_profiles: 'always',
+      autocapture: false,
+      disable_session_recording: true
+    });
+  </script>
+  <!-- End PostHog Analytics -->
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <meta name="theme-color" content="#4F7DC9">
   <meta charset="UTF-8">

--- a/site/app/views/archive/index.html
+++ b/site/app/views/archive/index.html
@@ -39,17 +39,17 @@
          <meta name="generator" content="{{view.title}}">
          <meta name="application-name" content="{{view.title}}">
          <link rel="canonical" href="{{canonicalViewUrl(view)}}" />
-         <link rel="preconnect" href="https://www.google-analytics.com" />
+         <!-- PostHog Analytics -->
          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '{{ga}}', 'auto');
-            ga('send', 'pageview');
-            {% if view.ga %}
-            ga('create', '{{view.ga}}', 'auto', { name: 'view' });
-            ga('view.send', 'pageview');
-            {% endif %}
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+            posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+               api_host: 'https://us.i.posthog.com',
+               person_profiles: 'always',
+               autocapture: false,
+               disable_session_recording: true
+            });
          </script>
-         <script async src='https://www.google-analytics.com/analytics.js'></script>
+         <!-- End PostHog Analytics -->
          <title>{{view.title}}</title>
          <link rel="stylesheet" href="/styles/main.css">
          {% if view.customStyle %}

--- a/site/app/views/default/index.html
+++ b/site/app/views/default/index.html
@@ -39,17 +39,17 @@
          <meta name="generator" content="{{view.title}}">
          <meta name="application-name" content="{{view.title}}">
          <link rel="canonical" href="{{canonicalViewUrl(view)}}" />
-         <link rel="preconnect" href="https://www.google-analytics.com" />
+         <!-- PostHog Analytics -->
          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '{{ga}}', 'auto');
-            ga('send', 'pageview');
-            {% if view.ga %}
-            ga('create', '{{view.ga}}', 'auto', { name: 'view' });
-            ga('view.send', 'pageview');
-            {% endif %}
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+            posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+               api_host: 'https://us.i.posthog.com',
+               person_profiles: 'always',
+               autocapture: false,
+               disable_session_recording: true
+            });
          </script>
-         <script async src='https://www.google-analytics.com/analytics.js'></script>
+         <!-- End PostHog Analytics -->
          <title>{{view.title}}</title>
          <link rel="stylesheet" href="/styles/main.css">
          {% if view.customStyle %}

--- a/site/app/views/deprecated/index.html
+++ b/site/app/views/deprecated/index.html
@@ -25,17 +25,17 @@
          <meta name="generator" content="{{view.title}}">
          <meta name="application-name" content="{{view.title}}">
          <link rel="canonical" href="{{canonicalViewUrl(view)}}" />
-         <link rel="preconnect" href="https://www.google-analytics.com" />
+         <!-- PostHog Analytics -->
          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '{{ga}}', 'auto');
-            ga('send', 'pageview');
-            {% if view.ga %}
-            ga('create', '{{view.ga}}', 'auto', { name: 'view' });
-            ga('view.send', 'pageview');
-            {% endif %}
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+            posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+               api_host: 'https://us.i.posthog.com',
+               person_profiles: 'always',
+               autocapture: false,
+               disable_session_recording: true
+            });
          </script>
-         <script async src='https://www.google-analytics.com/analytics.js'></script>
+         <!-- End PostHog Analytics -->
          <title>{{view.title}}</title>
          <link rel="stylesheet" href="/styles/main.css">
          {% if view.customStyle %}

--- a/site/app/views/embedding/index.html
+++ b/site/app/views/embedding/index.html
@@ -25,17 +25,17 @@
          <meta name="generator" content="{{view.title}}">
          <meta name="application-name" content="{{view.title}}">
          <link rel="canonical" href="{{canonicalViewUrl(view)}}" />
-         <link rel="preconnect" href="https://www.google-analytics.com" />
+         <!-- PostHog Analytics -->
          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '{{ga}}', 'auto');
-            ga('send', 'pageview');
-            {% if view.ga %}
-            ga('create', '{{view.ga}}', 'auto', { name: 'view' });
-            ga('view.send', 'pageview');
-            {% endif %}
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+            posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+               api_host: 'https://us.i.posthog.com',
+               person_profiles: 'always',
+               autocapture: false,
+               disable_session_recording: true
+            });
          </script>
-         <script async src='https://www.google-analytics.com/analytics.js'></script>
+         <!-- End PostHog Analytics -->
          <title>{{view.title}}</title>
          <link rel="stylesheet" href="/styles/main.css">
          {% if view.customStyle %}

--- a/site/app/views/firstfridayfeatures/index.html
+++ b/site/app/views/firstfridayfeatures/index.html
@@ -39,17 +39,17 @@
          <meta name="generator" content="{{view.title}}">
          <meta name="application-name" content="{{view.title}}">
          <link rel="canonical" href="{{canonicalViewUrl(view)}}" />
-         <link rel="preconnect" href="https://www.google-analytics.com" />
+         <!-- PostHog Analytics -->
          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '{{ga}}', 'auto');
-            ga('send', 'pageview');
-            {% if view.ga %}
-            ga('create', '{{view.ga}}', 'auto', { name: 'view' });
-            ga('view.send', 'pageview');
-            {% endif %}
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+            posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+               api_host: 'https://us.i.posthog.com',
+               person_profiles: 'always',
+               autocapture: false,
+               disable_session_recording: true
+            });
          </script>
-         <script async src='https://www.google-analytics.com/analytics.js'></script>
+         <!-- End PostHog Analytics -->
          <title>{{view.title}}</title>
          <link rel="stylesheet" href="/styles/main.css">
          {% if view.customStyle %}

--- a/site/app/views/internal/index.html
+++ b/site/app/views/internal/index.html
@@ -25,17 +25,17 @@
          <meta name="generator" content="{{view.title}}">
          <meta name="application-name" content="{{view.title}}">
          <link rel="canonical" href="{{canonicalViewUrl(view)}}" />
-         <link rel="preconnect" href="https://www.google-analytics.com" />
+         <!-- PostHog Analytics -->
          <script>
-            window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-            ga('create', '{{ga}}', 'auto');
-            ga('send', 'pageview');
-            {% if view.ga %}
-            ga('create', '{{view.ga}}', 'auto', { name: 'view' });
-            ga('view.send', 'pageview');
-            {% endif %}
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.people.toString(20)+" (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId setPersonPropertiesForFlags".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||(window.posthog=[]));
+            posthog.init('phc_zPt82AvdTv3BqU1Zwc5vXZnk8XUCjFnQ2RWsaN5ye4W', {
+               api_host: 'https://us.i.posthog.com',
+               person_profiles: 'always',
+               autocapture: false,
+               disable_session_recording: true
+            });
          </script>
-         <script async src='https://www.google-analytics.com/analytics.js'></script>
+         <!-- End PostHog Analytics -->
          <title>{{view.title}}</title>
          <link rel="stylesheet" href="/styles/main.css">
          {% if view.customStyle %}


### PR DESCRIPTION
## Summary
- Removes the legacy `analytics.js` GA snippet from all landing page view templates and the claat QS page template
- Adds the PostHog SDK snippet to all 7 files
- Configured with `person_profiles: 'always'` (anonymous visitor tracking), `autocapture: false`, `disable_session_recording: true`

## Context
GA tracking broke around July 8 when the consent provider was migrated from OneTrust to DataGrail. PostHog is the current analytics platform. This PR restores tracking coverage across the full site.

## Test plan
- [ ] Merge and deploy
- [ ] Visit quickstarts.sigmacomputing.com and confirm PostHog events appear in the PostHog real-time view
- [ ] Confirm \`\$pageview\` events are captured with correct host and pathname
- [ ] Verify ETL picks up new events for the Sigma analytics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)